### PR TITLE
Fix 'bak up' w/o existing bakfile - closes #41

### DIFF
--- a/bak/commands/__init__.py
+++ b/bak/commands/__init__.py
@@ -219,7 +219,9 @@ def bak_up_cmd(filename: str):
     old_bakfile = db_handler.get_bakfile_entries(filename)
     if old_bakfile == None:
         console.print(f"No bakfile found for {filename}")
-        return True
+        console.print(f"Creating {filename}.bak")
+        return create_bakfile(filename)
+
     # Disambiguate
     old_bakfile = old_bakfile[0] if len(old_bakfile) == 1 else \
         _do_select_bakfile(old_bakfile,

--- a/bak/data/bak_db.py
+++ b/bak/data/bak_db.py
@@ -60,7 +60,7 @@ class BakDBHandler():
                 """
                     SELECT * FROM bakfiles WHERE original_abspath=:orig
                 """, (os.path.abspath(os.path.expanduser(filename)),))
-            return [BakFile(*entry) for entry in c.fetchall()]
+            return [BakFile(*entry) for entry in c.fetchall()] or None
 
     def get_all_entries(self):
         with sqlite3.connect(self.db_loc) as db_conn:


### PR DESCRIPTION
bak_db.get_bakfile_entries() should return None instead of an empty list

'bak up' "No bakfile found" condition triggers correctly with bak_db fix

'bak up' without bakfile will now print the above, then create a bakfile

closes #41 (other request in another branch)