### PR TITLE
Improve bak list and selection; add config command, fastmode (fixes #35 #37 #40 #53 #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Don't worry, they're easy to remember after a minute:
 
 All of **bak**'s commands will disambiguate between multiple copies of the same file. In other words, you can `bak my_thing.txt` as many times as you want, until you're finished working, if you'd prefer to keep multiples instead of using `bak up`. At the moment, all you've got to go by are timestamps when it asks you to pick a .bakfile, but this will improve.
 
+**NOTE:** `bak down` will fall back on `sudo cp` if necessary. Please don't run `sudo bak`. This may create parallel config and bakfiles in root's XDG directories.
+
 ## Additional commands and flags
 
 `bak down --keep my_file` - Restores from .bakfile, does not delete .bakfile  

--- a/bak/__init__.py
+++ b/bak/__init__.py
@@ -1,1 +1,1 @@
-BAK_VERSION = "0.1.0a1"
+BAK_VERSION = "0.1.1a1"

--- a/bak/__main__.py
+++ b/bak/__main__.py
@@ -6,6 +6,7 @@ from click_default_group import DefaultGroup
 
 from bak import commands
 from bak import BAK_VERSION as bak_version
+from bak.configuration import bak_cfg as cfg
 
 
 def __print_help():
@@ -50,6 +51,7 @@ def bak():
 def _create(filename, version):
     create_bak_cmd(filename, version)
 
+
 @bak.command("create", hidden=True)
 @normalize_path()
 @click.option("--version", required=False, is_flag=True)
@@ -57,11 +59,13 @@ def _create(filename, version):
 def create(filename, version):
     create_bak_cmd(filename, version)
 
-# Ensures that 'bak --help' is printed if it doesn't get a filename
+
+
 def create_bak_cmd(filename, version):
     if version:
         click.echo(f"bak version {bak_version}")
     elif not filename:
+    # Ensures that 'bak --help' is printed if it doesn't get a filename
         __print_help()
     else:
         filename = Path(filename).expanduser().resolve()
@@ -154,19 +158,46 @@ def bak_diff(filename, using):
 
 @bak.command("list",
              help="List all .bakfiles, or a particular file's")
-@click.option("--relpaths",
+@click.option("--colors/--nocolors", "-c/-C",
+              help="Colorize output",
+              is_flag=True,
+              default=cfg['bak_list_colors'] and not cfg['fast_mode'])
+@click.option("--relpaths", "--rel", "-r",
               help="Display relative paths instead of abspaths",
               required=False,
               is_flag=True,
-              default=commands.bak_list_relpaths)
+              default=commands.BAK_LIST_RELPATHS)
+@click.option("--compare", "--diff", "-d",
+              help="Compare .bakfiles with current file, identify exact copies",
+              required=False,
+              is_flag=True,
+              default=False)
 @click.argument("filename",
                 required=False,
                 type=click.Path(exists=True))
 @normalize_path()
-def bak_list(relpaths, filename):
+def bak_list(colors, relpaths, compare, filename):
     if filename:
         filename = Path(filename).expanduser().resolve()
-    commands.show_bak_list(filename=filename or None, relative_paths=relpaths)
+    commands.show_bak_list(filename=filename or None,
+                           relative_paths=relpaths, colors=colors, compare=compare)
+
+
+TAB = '\t'
+CFG_HELP_TEXT = '\b\nGet/set config values. Valid settings include:\n\n\t' + \
+               f'\b\n{(TAB + cfg.newline).join(cfg.SETTABLE_VALUES)}' + \
+                '\b\n\nNOTE: diff-exec\'s value should be enclosed in quotes, and' \
+                '\nformatted like:\b\n\n\t\'diff %old %new\' \b\n\n(%old and %new will be substituted ' \
+                'with the bakfile and the original file, respectively)'
+
+
+@bak.command("config",
+             short_help="get/set config options", help=CFG_HELP_TEXT)
+@click.option("--get/--set", default=True)
+@click.argument("setting", required=True)
+@click.argument("value", required=False, nargs=-1, type=str)
+def bak_config(get, setting, value):
+    commands.bak_config_command(get, setting, value)
 
 
 if __name__ == "__main__":

--- a/bak/commands/__init__.py
+++ b/bak/commands/__init__.py
@@ -1,6 +1,8 @@
+# region lots of imports
 import os
 import sqlite3
 from datetime import datetime
+from filecmp import cmp as compare_files
 from pathlib import Path
 from shutil import copy2
 from subprocess import call
@@ -9,41 +11,38 @@ from typing import List, Optional
 from warnings import warn
 
 import click
-from config import Config
+from config import Config, KeyNotFoundError
 from rich import box
 from rich.color import Color
 from rich.console import Console
 from rich.style import Style
 from rich.table import Table
+from rich.text import Text
 
+from bak.configuration import bak_cfg as cfg
 from bak.data import bak_db, bakfile
+# endregion
 
-# TODO: customizable file extension
 
-try:
-    data_dir = Path(os.environ["XDG_DATA_HOME"]).expanduser().resolve()
-except KeyError:
-    data_dir = Path("~/.local/share").expanduser().resolve()
-try:
-    config_dir = Path(os.environ["XDG_CONFIG_HOME"]).expanduser().resolve()
-except KeyError:
-    config_dir = Path("~/.config").expanduser().resolve()
+# region constants etc.
+bak_dir = cfg['bakfile_location'] or cfg.data_dir / 'bak' / 'bakfiles'
+bak_db_loc = cfg['bak_database_location'] or cfg.data_dir / 'bak' / 'bak.db'
 
-config_file = config_dir / 'bak.cfg'
-cfg = Config(str(config_file))
-
-bak_dir = cfg['bakfile_location'] or data_dir / 'bak' / 'bakfiles'
-bak_db_loc = cfg['bak_database_location'] or data_dir / 'bak' / 'bak.db'
-
-bak_list_relpaths = cfg['bak_list_relative_paths']
-
+BAK_LIST_RELPATHS = cfg['bak_list_relative_paths']
+BAK_LIST_COLORS = cfg['bak_list_colors']
+FASTMODE = cfg['fast_mode']
 if not bak_dir.exists():
     bak_dir.mkdir(parents=True)
 
 db_handler = bak_db.BakDBHandler(bak_db_loc)
+# endregion
 
 
-def _assemble_bakfile(filename: Path):
+# region helpers
+############
+############
+############
+def __assemble_bakfile(filename: Path):
     time_now = datetime.now()
     bakfile_name = "".join(
         ["-".join(i for i in filename.parent.parts[1:])
@@ -54,36 +53,38 @@ def _assemble_bakfile(filename: Path):
                                     filename,
                                     bakfile_path,
                                     time_now,
-                                    time_now)
+                                    time_now,
+                                    restored=False)
     return new_bak_entry
 
 
 default_select_prompt = ("Enter a number, or: (V)iew (D)iff (C)ancel", 'C')
 
 
-def _get_bakfile_entry(filename: Path,
-                       select_prompt=default_select_prompt,
-                       err=True):
+def __get_bakfile_entry(filename: Path,
+                        select_prompt=default_select_prompt,
+                        err=True,
+                        diff=False):
     entries = db_handler.get_bakfile_entries(filename)
     if not entries:
         return None
     # If there's only one bakfile corresponding to filename, return that.
     # If there's more than one, disambiguate.
     return entries[0] if len(entries) == 1 else \
-        _do_select_bakfile(entries, select_prompt, err)
+        __do_select_bakfile(entries, select_prompt, err, diff)
+
+# TODO: this is a quick kludge to integrate 'bak list'
+# A proper rewrite is in order
 
 
-def _do_select_bakfile(bakfiles: List[bakfile.BakFile],
-                       select_prompt=default_select_prompt,
-                       err=True):
+def __do_select_bakfile(bakfiles: List[bakfile.BakFile],
+                        select_prompt=default_select_prompt,
+                        err=True,
+                        diff=True):
     console = Console(file=stderr if err else stdout)
-    console.print(
-        f"Found {len(bakfiles)} bakfiles for file: {bakfiles[0].orig_abspath}")
-    console.print("Please select from the following: ")
-    _range = range(len(bakfiles))
-    for i in _range:
-        console.print(
-            f"{i + 1}: .bakfile last modified at {bakfiles[i].date_modified.split('.')[0]}")
+
+    show_bak_list(bakfiles[0].orig_abspath, err=err, colors=(
+        BAK_LIST_COLORS and not FASTMODE), compare=diff)
 
     def get_choice():
         return click.prompt(*select_prompt, err=err).lower()
@@ -107,13 +108,9 @@ def _do_select_bakfile(bakfiles: List[bakfile.BakFile],
                     bak_diff_cmd(bakfiles[idx])
                     choice = get_choice()
                     continue
-                elif choice == "l":
-                    show_bak_list(bakfiles[0].orig_abspath)
-                    choice = get_choice()
-                    continue
                 else:
                     idx = int(choice) - 1
-                if idx not in _range:
+                if idx not in range(len(bakfiles)):
                     console.print("Invalid selection. Aborting.")
                     return False
                 elif view:
@@ -129,47 +126,206 @@ def _do_select_bakfile(bakfiles: List[bakfile.BakFile],
             get_choice()
 
 
+def __remove_bakfiles(bakfile_entries):
+    for entry in bakfile_entries:
+        Path(entry.bakfile_loc).unlink()
+        db_handler.del_bakfile_entry(entry)
+
+
+def __keep_bakfiles(bakfile_entry, bakfile_entries, new_destination):
+    if not new_destination:
+        for entry in bakfile_entries:
+            if all((entry.restored,
+                    entry.bakfile_loc != bakfile_entry.bakfile_loc)):
+                db_handler.set_restored_flag(entry, False)
+        db_handler.set_restored_flag(bakfile_entry, True)
+
+
+def __identify_baks(entries):
+    oldest_version: bakfile.BakFile
+    oldest_date = datetime.now()
+    newest_version: bakfile.BakFile
+    newest_date = datetime(1970, 1, 1, 1, 1)
+    for entry in entries:
+        timestamp = datetime.fromisoformat(entry.date_modified)
+        if timestamp < oldest_date:
+            oldest_version = entry
+            oldest_date = timestamp
+        if timestamp > newest_date:
+            newest_version = entry
+            newest_date = timestamp
+    return (oldest_version, newest_version)
+
+
+def __distinguish_baks(bakfiles):
+    filenames = set(_bakfile.orig_abspath for _bakfile in bakfiles)
+    _identified_baks = dict()
+    for _filename in filenames:
+        _identified_baks[_filename] = __identify_baks(
+            [_bakfile for _bakfile in bakfiles if _bakfile.orig_abspath == _filename])
+    return _identified_baks
+
+
+bold_style = Style(bold=True, italic=True)
+purple_style = Style(bold=True, italic=True, color="purple")
+blue_style = Style(color="blue")
+none_style = Style()
+
+
+def __generate_caption(colors, compare):
+    if colors:
+        caption = Text()
+        caption.append('-- ', style="red" if colors else none_style)
+        caption.append('oldest .bak   ', style='dim italic')
+        caption.append('++ ', style="green")
+        caption.append('newest .bak   ', style='dim italic')
+        caption.append('** ', style="yellow")
+        caption.append('restored   ', style='dim italic')
+        if compare:
+            caption.append('$ ', style="green")
+            caption.append('current version of file\n', style='dim italic')
+        else:
+            caption.append('\n')
+        caption.append(
+            '   (files may have been edited since restoration)', style='dim italic')
+    else:
+        caption = '-- oldest .bak   ++ newest .bak   ** restored' +\
+            ('  $ current version of file' if compare else '') +\
+            '\n   (files may have been edited since restoration)'
+    return caption
+
+
+def __prep_list_row(_bakfile,
+                    compare,
+                    colors,
+                    current_style,
+                    filename_exists,
+                    relative_paths,
+                    current_filename,
+                    _identified_baks,
+                    i):
+    # Apply identifying markers to indices
+    if compare:
+        current_version_marker = \
+            Text("$ ") if compare_files(
+                _bakfile.bakfile_loc, current_filename) else None
+    else:
+        current_version_marker = None
+
+    restored_marker = \
+        Text('** ') if _bakfile.restored else None
+
+    _id_baks = _identified_baks[_bakfile.orig_abspath]
+    marker = ('-- ' if _bakfile is _id_baks[0]
+              else ('++ ' if _bakfile is _id_baks[1]
+                    else ""))
+    marker = Text(marker) if marker else Text()
+
+    if colors:
+        if restored_marker:
+            restored_marker.stylize("yellow")
+        if current_version_marker:
+            current_version_marker.stylize("green")
+        if marker:
+            marker.stylize(
+                "green" if '+' in marker else "red" if '-' in marker else None)
+        index = marker.append(str(i))
+    else:
+        index = marker.append_text(Text(str(i)))
+    index.stylize("bold")
+
+    if restored_marker:
+        index = restored_marker.append_text(index)
+    if current_version_marker:
+        if not (marker or restored_marker):
+            current_version_marker += "   "
+        index = current_version_marker.append_text(index)
+
+    # Prepare and stylize this row's content
+    o_path = Text(os.path.relpath(current_filename) if
+                  relative_paths else
+                  current_filename)
+    o_created = Text(_bakfile.date_created.split('.')[0])
+    o_modified = Text(_bakfile.date_modified.split('.')[0])
+
+    o_path.stylize('green' if filename_exists and colors else current_style)
+    o_created.stylize(current_style)
+    o_modified.stylize(current_style)
+
+    return (index, o_path, o_created, o_modified)
+########################
+########################
+########################
+# endregion
+
+
 def show_bak_list(filename: Optional[Path] = None,
-                  relative_paths: bool = False):
+                  relative_paths: bool = BAK_LIST_RELPATHS,
+                  err=False,
+                  colors: bool = BAK_LIST_COLORS,
+                  compare: bool = False):
     """ Prints list of .bakfiles with metadata
 
     Arguments:
         filename (str|os.path, optional):
         List only `filename`'s .bakfiles
     """
-    # pass
+
+    def _rotate_style(bold: bool):
+        if not colors:
+            return bold_style if bold else none_style
+        return purple_style if bold else blue_style
+
+    # Get bakfiles
     bakfiles: List[bakfile.BakFile]
     bakfiles = db_handler.get_bakfile_entries(filename) if filename else \
         db_handler.get_all_entries()
 
-    console = Console()
+    console = Console(file=stderr if err else stdout)
     if not bakfiles:
         console.print(f"No .bakfiles found for "
                       f"{filename}" if
                       filename else "No .bakfiles found")
         return
 
-    _title = f".bakfiles of {filename}" if \
-        filename else ".bakfiles"
-
-    table = Table(title=_title,
-                  show_lines=True, box=box.HEAVY_EDGE)
-
-    table.add_column("")
+    # Set up table
+    table = Table(title=(f".bakfiles of {filename}" if
+                         filename else ".bakfiles"),
+                  show_lines=True,
+                  box=box.HEAVY_EDGE,
+                  caption=__generate_caption(colors, compare))
+    table.add_column("", justify='right', style=None)
     table.add_column("Original File")
     table.add_column("Date Created")
     table.add_column("Last Modified")
 
+    # Distinguish .bakfiles from different original files
     i = 1
-    for _bakfile in bakfiles:
-        table.add_row(str(i),
-                      filename.relative_to(Path.cwd()) if
-                      relative_paths else
-                      _bakfile.orig_abspath,
-                      _bakfile.date_created.split('.')[0],
-                      _bakfile.date_modified.split('.')[0])
-        i += 1
+    current_filename = bakfiles[0].orig_abspath
+    current_style = blue_style if colors else none_style
+    bold = False  # First line will be opposite, toggled between population and rendering of table row
 
+    # Begin individual row prep and add
+    for _bakfile in bakfiles:
+        _id_baks = __distinguish_baks(bakfiles)
+        # Alternate styles on every other filename
+        if current_filename != _bakfile.orig_abspath:
+            current_filename = _bakfile.orig_abspath
+            bold = not bold
+            current_style = _rotate_style(bold)
+
+        table.add_row(*__prep_list_row(_bakfile,  # the current row's bakfile
+                                       compare,  # options
+                                       colors,
+                                       current_style,
+                                       filename is not None,
+                                       relative_paths,  # end options
+                                       current_filename,  # orig_abspath
+                                       _id_baks,  # oldest/newest/restored
+                                       i  # current row index
+                                       ))
+        i += 1
+    # End table prep
     console.print(table)
 
 
@@ -184,7 +340,14 @@ def create_bakfile(filename: Path):
     if not filename.exists():
         # TODO descriptive failure
         return False
-    new_bakfile = _assemble_bakfile(filename)
+    current_entries = db_handler.get_bakfile_entries(
+        filename.expanduser().resolve())
+    if current_entries:
+        if compare_files(__identify_baks(current_entries)[1].bakfile_loc, filename.expanduser().resolve()):
+            if not click.confirm("No changes to file since last bak. Would you like to create a duplicate .bakfile?"):
+                click.echo("Cancelled.")
+                return
+    new_bakfile = __assemble_bakfile(filename)
     copy2(new_bakfile.orig_abspath, new_bakfile.bakfile_loc)
     db_handler.create_bakfile_entry(new_bakfile)
 
@@ -210,9 +373,9 @@ def bak_up_cmd(filename: Path):
 
     # Disambiguate
     old_bakfile = old_bakfile[0] if len(old_bakfile) == 1 else \
-        _do_select_bakfile(old_bakfile,
-                           select_prompt=(
-                               ("Enter a number to overwrite a .bakfile, or:\n(V)iew (L)ist (C)ancel", "C")))
+        __do_select_bakfile(old_bakfile,
+                            select_prompt=(
+                                ("Enter a number to overwrite a .bakfile, or:\n(V)iew (C)ancel", "C")))
 
     if old_bakfile is None:
         console.print("Cancelled.")
@@ -244,32 +407,36 @@ def bak_down_cmd(filename: Path,
         destination (None|Path): destination path to restore to
     """
     console = Console()
+    new_destination = False
     bakfile_entries = db_handler.get_bakfile_entries(filename)
     if not bakfile_entries:
         console.print(f"No bakfiles found for {filename}")
         return
 
-    bakfile_entry = _do_select_bakfile(bakfile_entries) if len(
+    bakfile_entry = __do_select_bakfile(bakfile_entries) if len(
         bakfile_entries) > 1 else bakfile_entries[0]
 
-    if bakfile_entry is None:
-        console.print(f"No bakfiles found for {filename}")
+    if not bakfile_entry:
+        console.print(f"No bakfiles found for {filename}" if bakfile_entry is None else "")
         return
-    elif not bakfile_entry:
-        return
-    if not destination:
-        destination = Path(bakfile_entry.orig_abspath).expanduser()
+    if destination:
+        new_destination = destination.expanduser() != bakfile_entry.orig_abspath
+    else:
+        destination = Path(bakfile_entry.orig_abspath)
 
     if quiet:
         confirm = 'y'
     else:
-        if destination != bakfile_entry.orig_abspath:
-            if destination.exists():
-                confirm = click.confirm(f"Overwrite {destination}?")
-        
-        confirm_prompt = f"Confirm: Restore {filename} to {destination} and erase bakfiles?" \
-            if not keep_bakfile else \
-            f"Confirm: Restore {filename} to {destination} and keep bakfiles?"
+        if all((new_destination, destination.exists())):
+            if not click.confirm(f"Overwrite {destination}?", default=False):
+                click.echo("Cancelled.")
+                return
+
+        erase = 'keep' if keep_bakfile else 'erase'
+        confirm_prompt = f"Confirm: Restore {filename}"
+        confirm_prompt += f" to {destination}" if new_destination else ""
+        confirm_prompt += f" and {erase} bakfiles?"
+
         confirm = click.confirm(confirm_prompt, default=False)
     if not confirm:
         console.print("Cancelled.")
@@ -283,12 +450,18 @@ def bak_down_cmd(filename: Path,
         for entry in bakfile_entries:
             Path(entry.bakfile_loc).unlink(missing_ok=True)
             db_handler.del_bakfile_entry(entry)
+    else:
+        copy2(bakfile_entry.bakfile_loc, bakfile_entry.orig_abspath)
+        if not new_destination:
+            for entry in bakfile_entries:
+                if entry.restored:
+                    if entry.bakfile_loc != bakfile_entry.bakfile_loc:
+                        db_handler.set_restored_flag(entry, False)
+            db_handler.set_restored_flag(bakfile_entry, True)
 
-
-def __remove_bakfiles(bakfile_entries):
-    for entry in bakfile_entries:
-        Path(entry.bakfile_loc).unlink()
-        db_handler.del_bakfile_entry(entry)
+    args = [bakfile_entries] if not keep_bakfile else [bakfile_entry, bakfile_entries, new_destination]
+    helper = __keep_bakfiles if keep_bakfile else __remove_bakfiles
+    helper(*args)
 
 
 def bak_off_cmd(filename: Optional[Path],
@@ -327,17 +500,17 @@ def bak_print_cmd(bak_to_print: (str, bakfile.BakFile),
     console = Console()
 
     if not isinstance(bak_to_print, bakfile.BakFile):
-        _bak_to_print = _get_bakfile_entry(bak_to_print,
-                                           select_prompt=(
-                                               "Enter a number to select a .bakfile, or:\n(D)iff (L)ist (C)ancel",
-                                               "C"))
+        _bak_to_print = __get_bakfile_entry(bak_to_print,
+                                            select_prompt=(
+                                                "Enter a number to select a .bakfile, or:\n(D)iff (C)ancel",
+                                                "C"))
         if _bak_to_print is None:
             console.print(
                 f"No bakfiles found for {Path(bak_to_print).resolve()}")
         else:
             bak_to_print = _bak_to_print
         if not isinstance(bak_to_print, bakfile.BakFile):
-            return  # _get_bakfile_entry() handles failures, so just exit here
+            return  # __get_bakfile_entry() handles failures, so just exit here
     pager = using if using else \
         (cfg['bak_open_exec'] or os.environ['PAGER']) or 'less'
     pager = pager.strip('"').strip("'").split(" ")
@@ -349,28 +522,60 @@ def bak_getfile_cmd(bak_to_get: (str, bakfile.BakFile)):
 
     if not isinstance(bak_to_get, bakfile.BakFile):
         filename = bak_to_get
-        bak_to_get = _get_bakfile_entry(bak_to_get, err=True)
+        bak_to_get = __get_bakfile_entry(bak_to_get, err=True)
         if bak_to_get is None:
             console.print(f"No bakfiles found for {Path(filename).resolve()}")
-            return  # _get_bakfile_entry() handles failures, so just exit
+            return  # __get_bakfile_entry() handles failures, so just exit
     print(bak_to_get.bakfile_loc)
 
 
-def bak_diff_cmd(filename: (bakfile.BakFile, Path), command='diff'):
+def bak_diff_cmd(filename: (bakfile.BakFile, Path), command=None):
+    '''
+    Expects a config value for its exec along the lines of:
+        diff %old %new
+    or:
+        diff -r %old %new
+    which will be substituted with the bakfile and the original file.
+    '''
     # TODO write tests for this (mildly tricky)
     console = Console()
-
     bak_to_diff = filename if isinstance(filename, bakfile.BakFile) else \
-        _get_bakfile_entry(filename,
-                           select_prompt=(
-                               ("Enter a number to diff a .bakfile, or:\n(V)iew (L)ist (C)ancel", "C")))
+        __get_bakfile_entry(filename,
+                            diff=not FASTMODE,
+                            select_prompt=(
+                                ("Enter a number to diff a .bakfile, or:\n(V)iew (C)ancel", "C")))
     if not command:
-        command = cfg['bak_diff_exec'] or 'diff'
+        command = cfg['bak_diff_exec']
+        if not command or any((i not in command.lower() for i in ['%old', '%new'])):
+            command = 'diff %old %new'
     if bak_to_diff is None:
         console.print(f"No bakfiles found for {filename}")
         return
     if not bak_to_diff:
         return
+    command = command.lower().replace('%old', bak_to_diff.bakfile_loc).replace('%new', bak_to_diff.orig_abspath)
     command = command.strip('"').strip("'").split(" ")
-    call(command +
-         [bak_to_diff.bakfile_loc, bak_to_diff.orig_abspath])
+
+    call(command)
+    # call(command +
+    #      [bak_to_diff.bakfile_loc, bak_to_diff.orig_abspath])
+
+
+def bak_config_command(get_op: bool, setting: str, value: tuple = ()):
+    # TODO make a proper Click help formatter for this and certain other functions
+    # (Click does weird things with tabs and newlines, and this nonsense is
+    # required just to obtain the unsatisfactory result we've got.)
+    if setting not in cfg.SETTABLE_VALUES:
+        click.echo("Invalid setting. Valid choices include:\n\t\t\t"
+                   + "\n\t\t\t".join(option for option in cfg.SETTABLE_VALUES))
+        return
+    if any((get_op, value == ())):
+        try:
+            click.echo(cfg.get(setting, literal=True))
+        except KeyError:
+            click.echo(f"Unknown option {setting}")
+    else:
+        try:
+            cfg[setting] = ' '.join(value)
+        except KeyNotFoundError as err:
+            click.echo(err)

--- a/bak/configuration/__init__.py
+++ b/bak/configuration/__init__.py
@@ -1,0 +1,125 @@
+# Straight file. Read config into variables. Probably no need for a data structure.
+import os
+
+from pathlib import Path
+from re import sub
+
+from config import Config, KeyNotFoundError
+
+
+class BakConfiguration(dict):
+    # Establish default config values
+    DEFAULT_VALUES = {
+        'bakfile_location': 'null',
+        'bak_database_location': 'null',
+        'bak_diff_exec': 'null',
+        'bak_list_relative_paths': 'false',
+        'bak_list_colors': 'true',
+        'fast_mode': 'false'
+    }
+
+    SETTABLE_VALUES = {
+        'diff-exec': 'bak_diff_exec',
+        'relative-paths': 'bak_list_relative_paths',
+        'colors': 'bak_list_colors',
+        'fast-mode': 'fast_mode'
+    }
+    cfg: Config
+    config_file: str
+    data_dir: Path
+    config_dir: Path
+    newline: str
+
+    values: dict
+
+    def __init__(self):
+
+        self.values = {}
+        self.newline = '\n'
+
+        # Establish config file and database locations
+        try:
+            self.data_dir = Path(
+                os.environ["XDG_DATA_HOME"]).expanduser().resolve()
+        except KeyError:
+            self.data_dir = Path("~/.local/share").expanduser().resolve()
+        try:
+            self.config_dir = Path(
+                os.environ["XDG_CONFIG_HOME"]).expanduser().resolve()
+        except KeyError:
+            self.config_dir = Path("~/.config").expanduser().resolve()
+
+        self.config_file = self.config_dir / 'bak.cfg'
+        _cfg = Config(str(self.config_file))
+
+        reload = False
+        for cfg_value in self.DEFAULT_VALUES:
+            if cfg_value not in _cfg.as_dict():
+                with open(self.config_file, 'w') as _file:
+                    _file.write(
+                        f"{cfg_value}: {self.DEFAULT_VALUES[cfg_value]}\n")
+                    _file.close()
+                    reload = True
+        if reload:
+            _cfg = Config(str(self.config_file))
+
+        self.cfg = _cfg
+
+        super().__init__()
+
+    def __getitem__(self, item):
+        if item in self.SETTABLE_VALUES:
+            item = self.SETTABLE_VALUES[item]
+        return translate_config_value(self.cfg[item])
+
+    def get(self, item, literal=True):
+        """
+        "Override" dict.get() in specific cases: use this to get the actual value of complex options,
+        rather than whatever bak parses it into (like the actual command for `bak diff`, rather than
+        an array of commands and arguments)
+
+        Called by `bak config <value>`, just for good measure
+        """
+        if literal:
+            # `and` would work, but why make the second check if this is a regular dict.get()?
+            if item in self.SETTABLE_VALUES:
+                return self.cfg[self.SETTABLE_VALUES[item]]
+        return super().get(item)
+
+    def __setitem__(self, item: str, value: str):
+        if item in self.SETTABLE_VALUES:
+            item = self.SETTABLE_VALUES[item]
+        if item not in self.DEFAULT_VALUES:
+            err = f"{item} is not a valid bak setting. Valid settings include:\n"
+            for setting in self.DEFAULT_VALUES:
+                err += f"\n\t\t\t{setting + self.newline}"
+            raise KeyNotFoundError(err)
+        if str(value).lower not in ('true', 'false'):
+            if value is None or value.lower() == 'none':
+                value = 'null'
+            else:
+                value = f"'{value}'"
+
+            _config = None
+            with open(self.config_file, 'r') as _file:
+                _config = _file.read()
+            _config = sub(f"{item}: .*", f"{item}: {value}", _config)
+            with open(self.config_file, 'w') as _file:
+                _file.write(_config)
+            self.cfg = Config(str(self.config_file))
+
+
+EQUIVALENT_VALUES = {'false': False,
+                     'true': True,
+                     'null': None}
+
+
+def translate_config_value(val):
+    if val in EQUIVALENT_VALUES.values():
+        return val
+    if val not in EQUIVALENT_VALUES:
+        return val
+    return EQUIVALENT_VALUES[val]
+
+
+bak_cfg = BakConfiguration()

--- a/bak/data/bak_db.py
+++ b/bak/data/bak_db.py
@@ -7,27 +7,39 @@ from .bakfile import BakFile
 
 class BakDBHandler:
     db_loc: Path
+    COL_NAMES = ['original_file', 'original_abspath',
+                 'bakfile', 'date_created', 'date_modified', 'restored']
 
     def __init__(self, db_loc: Path):
         self.db_loc = db_loc
 
         if not self.db_loc.exists():
-            db_conn = sqlite3.connect(self.db_loc)
-            db_conn.execute("""
-                            CREATE TABLE bakfiles (original_file,
-                                                   original_abspath,
-                                                   bakfile,
-                                                   date_created,
-                                                   date_modified)
-                            """)
-            db_conn.commit()
+            with sqlite3.connect(self.db_loc) as db_conn:
+                db_conn.execute("""
+                                CREATE TABLE bakfiles (original_file,
+                                                        original_abspath,
+                                                        bakfile,
+                                                        date_created,
+                                                        date_modified,
+                                                        restored)
+                                """)
+                db_conn.commit()
+        else:
+            with sqlite3.connect(self.db_loc) as db_conn:
+                cur = db_conn.cursor()
+                cur.execute("SELECT * from bakfiles")
+                db_cols = [name[0] for name in cur.description]
+                for col in self.COL_NAMES:
+                    if col not in db_cols:
+                        cur.execute(f"ALTER TABLE bakfiles ADD COLUMN {col}")
+                        db_conn.commit()
 
     def create_bakfile_entry(self, bakfile_obj: BakFile):
         with sqlite3.connect(self.db_loc) as db_conn:
             db_conn.execute(
                 """
                 INSERT INTO bakfiles VALUES
-                (:orig, :abs, :bakfile, :created, :modified)
+                (:orig, :abs, :bakfile, :created, :modified, :restored)
                  """, bakfile_obj.export())
             db_conn.commit()
 
@@ -53,17 +65,27 @@ class BakDBHandler:
                 self.create_bakfile_entry(new_bakfile)
             else:
                 self.create_bakfile_entry(old_bakfile)
+                self.set_restored_flag(old_bakfile, False)
+
+    def set_restored_flag(self, bakfile, status=True):
+        with sqlite3.connect(self.db_loc) as db_conn:
+            db_conn.execute(
+                """
+                UPDATE bakfiles SET restored=:status WHERE bakfile=:bakfile_loc
+                """, (status, bakfile.bakfile_loc)
+            )
 
     # TODO handle disambiguation
     def get_bakfile_entries(self, filename):
         with sqlite3.connect(self.db_loc) as db_conn:
             cursor = db_conn.execute(
                 """
-                    SELECT * FROM bakfiles WHERE original_abspath=:orig
+                    SELECT * FROM bakfiles WHERE original_abspath=:orig ORDER BY date_created
                 """, (os.path.abspath(os.path.expanduser(filename)),))
             return [BakFile(*entry) for entry in cursor.fetchall()] or None
 
     def get_all_entries(self):
         with sqlite3.connect(self.db_loc) as db_conn:
-            cursor = db_conn.execute("SELECT * FROM bakfiles")
+            cursor = db_conn.execute(
+                "SELECT * FROM bakfiles ORDER BY original_abspath, date_created")
             return [BakFile(*entry) for entry in cursor.fetchall()]

--- a/bak/data/bakfile.py
+++ b/bak/data/bakfile.py
@@ -14,13 +14,15 @@ class BakFile:
                  orig_abspath: Path,
                  bakfile: Path,
                  created: datetime,
-                 modified: datetime):
+                 modified: datetime,
+                 restored: bool):
         self.original_file, \
             self.orig_abspath, \
             self.bakfile_loc, \
             self.date_created, \
-            self.date_modified = \
-            original, orig_abspath, bakfile, created, modified
+            self.date_modified, \
+            self.restored = \
+            original, orig_abspath, bakfile, created, modified, restored
 
     def export(self):
         return((
@@ -28,5 +30,6 @@ class BakFile:
             str(self.orig_abspath),
             str(self.bakfile_loc),
             self.date_created,
-            self.date_modified
+            self.date_modified,
+            self.restored
         ))

--- a/bak/default.cfg
+++ b/bak/default.cfg
@@ -7,13 +7,20 @@
 # This will be addressed before release. For now, if you aren't
 # familiar with the module, stick to string values.
 
-bakfile_location: null # Default: $XDG_DATA_HOME/bak/bakfiles
-bak_database_location: null # Default: $XDG_DATA_HOME/bak/bak.db
+# Default: $XDG_DATA_HOME/bak/bakfiles
+bakfile_location: null
+# Default: $XDG_DATA_HOME/bak/bak.db
+bak_database_location: null
 
 # Example:
 # bak_open_exec: 'less'
 # (you'll need those single quotes for anything other than null)
-bak_open_exec: null # Defaults to $PAGER
-bak_diff_exec: null # Defaults to system diff
+
+# bak_open_exec defaults to $PAGER
+bak_open_exec: null
+# bak_diff_exec defaults to system diff
+# Format new settings as per: 'diff %old %new'
+bak_diff_exec: 'diff %old %new'
 
 bak_list_relative_paths: False
+bak_list_colors: True

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ require = ['click==7.1.2',
            'rich==9.1.0']
 
 setup(name='bak',
-      version='0.1.0a1',
+      version='0.1.1a1',
       description='the .bak manager',
       author='ChanceNCounter',
       author_email='ChanceNCounter@icloud.com',


### PR DESCRIPTION
Several, initially OOS feature branches wrapped into one.

* Combines `bak list` and the selector output from other commands, turns it into a table, colorizes it, and adds the following indicators, per original file:
    * Newest (most recently created/updated) .bakfile
    * Oldest (least recently created/updated) .bakfile
    * Bakfile most recently restored
    * Bakfiles identical to the current version of original (not shown in `bak list` without flag; always shown in `bak diff` without config setting)
* Adds the following config values:
    * colors
    * `bak diff` check for dupes (slow on slow computers or very large files, nevertheless on by default)
    * "fast mode" (most "slow" stuff always off, incl. colors, dupe check, and other formatting fun)
* Creates a command `bak config` to get/set certain config values, including the above