### PR TITLE
fix #73: show --version in help; bump 0.2.2 cycle (finally)

### DIFF
--- a/bak/__init__.py
+++ b/bak/__init__.py
@@ -1,1 +1,1 @@
-BAK_VERSION = "0.2.1a1"
+BAK_VERSION = "0.2.2a1"

--- a/bak/__main__.py
+++ b/bak/__main__.py
@@ -39,7 +39,10 @@ BASIC_HELP_TEXT = "bak FILENAME (creates a bakfile)\n\nalias: bak create\n\n" +\
     "See also: bak COMMAND --help"
 
 
-@click.group(cls=DefaultGroup, default='\0', default_if_no_args=True, help=BASIC_HELP_TEXT)
+@click.group(cls=DefaultGroup, default='\0', no_args_is_help=True, help=BASIC_HELP_TEXT,
+             invoke_without_command=True)
+# The --version option is duplicated here to make Click render it in bak --help
+@click.option("--version", required=False, is_flag=True, help="Print current version and exit.")
 def bak():
     pass
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ require = ['click==7.1.2',
            'rich==9.1.0']
 
 setup(name='bak',
-      version='0.2.1a1',
+      version='0.2.2a1',
       description='the .bak manager',
       author='ChanceNCounter',
       author_email='ChanceNCounter@icloud.com',


### PR DESCRIPTION
closes #73 