### PR TITLE
Add 'bak del/bak rm' and 'bak down --keep'

### DIFF
--- a/bak/__init__.py
+++ b/bak/__init__.py
@@ -1,1 +1,1 @@
-BAK_VERSION = "0.2.2a2"
+BAK_VERSION = "0.2.2a3"

--- a/bak/data/bak_db.py
+++ b/bak/data/bak_db.py
@@ -44,6 +44,14 @@ class BakDBHandler:
             db_conn.commit()
 
     def del_bakfile_entry(self, bak_entry: BakFile):
+       with sqlite3.connect(self.db_loc) as db_conn:
+            db_conn.execute(
+                """
+                DELETE FROM bakfiles WHERE bakfile=:bakfile
+                """, (bak_entry.bakfile_loc,))
+            db_conn.commit() 
+
+    def del_all_entries(self, bak_entry: BakFile):
         with sqlite3.connect(self.db_loc) as db_conn:
             db_conn.execute(
                 """

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ require = ['click==7.1.2',
            'rich==9.1.0']
 
 setup(name='bak',
-      version='0.2.2a2',
+      version='0.2.2a3',
       description='the .bak manager',
       author='ChanceNCounter',
       author_email='ChanceNCounter@icloud.com',


### PR DESCRIPTION
Closes #45 

* New command: bak del
  * alias: bak rm
  * Deletes a single .bakfile by number
  * Uses the displayed numbers from bak list, not Python indices,
    and trusts the rest of bak to provide consistent numbering
* New option: bak down --keep|-k (all|#) [#...]
  * Keeps some bakfiles while invoking bak down
  * Accepts one ~~or more~~ bakfile number~~s~~, or the word 'all'
  * Can be invoked multiple times